### PR TITLE
refactor: Remove versions from get_provider_info

### DIFF
--- a/firebolt_provider/__init__.py
+++ b/firebolt_provider/__init__.py
@@ -8,5 +8,4 @@ def get_provider_info() -> Dict[str, Any]:
         "description": "A Firebolt provider for Apache Airflow.",
         "hook-class-names": ["firebolt_provider.hooks.firebolt.FireboltHook"],
         "extra-links": ["firebolt_provider.operators.firebolt.RegistryLink"],
-        "versions": ["0.0.1"],
     }


### PR DESCRIPTION
versions is no longer a part of get_provider_info information:
https://github.com/apache/airflow/blob/main/airflow/provider_info.schema.json
Change made in https://github.com/apache/airflow/pull/14119