### PR TITLE
fix: Fir 15232 15233 configuration options

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,3 +44,25 @@ jobs:
         with:
           name: pytest-coverage-report
           path: coverage.xml
+
+      - name: Extract coverage percent
+        id: coverage
+        continue-on-error: true
+        run: |
+          fraction=$(sed -n 2p coverage.xml | sed 's/.*line-rate=\"\([0-9.]*\)\".*$/\1/')
+          percentage=$(echo "scale=1; $fraction * 100" | bc -l)
+          percentage_whole=$(echo "${percentage%.*}")
+          colour=$(if [ $percentage_whole -ge 80 ]; then echo "green"; else echo "orange"; fi)
+          echo "::set-output name=colour::$colour"
+          echo "::set-output name=covered::$percentage_whole"
+    
+      - name: Create Coverage Badge
+        uses: schneegans/dynamic-badges-action@v1.4.0
+        continue-on-error: true
+        with:
+          auth: ${{ secrets.GIST_PAT }}
+          gistID: 22e274394fed6421b6f5d5a2c8016fa3
+          filename: firebolt-cli-coverage.json
+          label: Coverage
+          message: ${{steps.coverage.outputs.covered}}%
+          color: ${{steps.coverage.outputs.colour}}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@
 
 # Firebolt Provider for Apache Airflow
 
+[![Unit tests](https://github.com/firebolt-db/airflow-provider-firebolt/actions/workflows/pull-request.yml/badge.svg)](https://github.com/firebolt-db/airflow-provider-firebolt/actions/workflows/pull-request.yml)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/yuryfirebolt/22e274394fed6421b6f5d5a2c8016fa3/raw/firebolt-airflow-provider-coverage.json
+)
+
+
 <img width="1114" alt="Screen Shot 2022-02-02 at 2 57 37 PM" src="https://user-images.githubusercontent.com/7674553/152251803-427f45b5-2160-4434-9f3e-431db4d3e79e.png">
 
 This is the provider package for the `firebolt` provider. All classes for this provider package are in the `firebolt_provider` Python package.
@@ -41,7 +46,7 @@ You can install this package via
 pip install airflow-provider-firebolt
 ```
 
-`airflow-provider-firebolt` requires `apache-airflow` 2.2.0+ and `firebolt-sdk` 0.2.0+.
+`airflow-provider-firebolt` requires `apache-airflow` 2.2.0+ and `firebolt-sdk` 0.9.2+.
 
 
 <a id="configuration"></a>
@@ -64,6 +69,11 @@ In the Airflow user interface, configure a Connection for Firebolt. Most of the 
 ### Operators
 
 [operators.firebolt.FireboltOperator](https://github.com/firebolt-db/airflow-provider-firebolt/blob/main/firebolt_provider/operators/firebolt.py) runs a provided SQL script against Firebolt and returns results.
+
+[operators.firebolt.FireboltStartEngineOperator](https://github.com/firebolt-db/airflow-provider-firebolt/blob/main/firebolt_provider/operators/firebolt.py) 
+[operators.firebolt.FireboltStopEngineOperator](https://github.com/firebolt-db/airflow-provider-firebolt/blob/main/firebolt_provider/operators/firebolt.py) starts/stops the specified engine, and waits until it is actually started/stopped. If the `engine_name` is not specified, it will use the `engine_name` from the connection, if it also not specified it will start the default engine of the connection database. Note: start/stop operator requires actual engine name, if engine URL is specified instead, start/stop engine operators will not be able to handle it correctly.
+
+
 
 
 <a id="hooks"></a>

--- a/firebolt_provider/example_dags/example_firebolt.py
+++ b/firebolt_provider/example_dags/example_firebolt.py
@@ -31,7 +31,6 @@ from firebolt_provider.operators.firebolt import (
 FIREBOLT_CONN_ID = "firebolt_conn_id"
 FIREBOLT_SAMPLE_TABLE = "sample_table"
 FIREBOLT_DATABASE = "sample_database"
-PATH_TO_TEMPLATES = "/full/path/to/templates/"
 
 # SQL commands
 SQL_CREATE_TABLE_STATEMENT = (
@@ -53,7 +52,6 @@ with DAG(
     default_args={"firebolt_conn_id": FIREBOLT_CONN_ID},
     tags=["example"],
     catchup=False,
-    template_searchpath=[PATH_TO_TEMPLATES],
 ) as dag:
     firebolt_start_engine = FireboltStartEngineOperator(task_id="firebolt_start_engine")
     firebolt_stop_engine = FireboltStopEngineOperator(task_id="firebolt_stop_engine")

--- a/firebolt_provider/example_dags/example_firebolt.py
+++ b/firebolt_provider/example_dags/example_firebolt.py
@@ -59,7 +59,7 @@ with DAG(
     firebolt_stop_engine = FireboltStopEngineOperator(task_id="firebolt_stop_engine")
     firebolt_op_sql_create_table = FireboltOperator(
         task_id="firebolt_op_sql_create_table",
-        sql="firebolt_op_sql_create_table.sql",
+        sql=SQL_CREATE_TABLE_STATEMENT,
     )
 
     firebolt_op_sql_list = FireboltOperator(

--- a/firebolt_provider/example_dags/example_firebolt.py
+++ b/firebolt_provider/example_dags/example_firebolt.py
@@ -31,7 +31,7 @@ from firebolt_provider.operators.firebolt import (
 FIREBOLT_CONN_ID = "firebolt_conn_id"
 FIREBOLT_SAMPLE_TABLE = "sample_table"
 FIREBOLT_DATABASE = "sample_database"
-FIREBOLT_ENGINE = "sample_engine"
+PATH_TO_TEMPLATES = "/full/path/to/templates/"
 
 # SQL commands
 SQL_CREATE_TABLE_STATEMENT = (
@@ -53,17 +53,13 @@ with DAG(
     default_args={"firebolt_conn_id": FIREBOLT_CONN_ID},
     tags=["example"],
     catchup=False,
+    template_searchpath=[PATH_TO_TEMPLATES],
 ) as dag:
-    firebolt_start_engine = FireboltStartEngineOperator(
-        task_id="firebolt_start_engine", engine_name=FIREBOLT_ENGINE
-    )
-    firebolt_stop_engine = FireboltStopEngineOperator(
-        task_id="firebolt_stop_engine", engine_name=FIREBOLT_ENGINE
-    )
-
+    firebolt_start_engine = FireboltStartEngineOperator(task_id="firebolt_start_engine")
+    firebolt_stop_engine = FireboltStopEngineOperator(task_id="firebolt_stop_engine")
     firebolt_op_sql_create_table = FireboltOperator(
         task_id="firebolt_op_sql_create_table",
-        sql=SQL_CREATE_TABLE_STATEMENT,
+        sql="firebolt_op_sql_create_table.sql",
     )
 
     firebolt_op_sql_list = FireboltOperator(

--- a/firebolt_provider/hooks/firebolt.py
+++ b/firebolt_provider/hooks/firebolt.py
@@ -113,11 +113,12 @@ class FireboltHook(DbApiHook):
         if engine_name and "." in engine_name:
             engine_name, engine_url = None, engine_name
 
+        api_endpoint = conn.extra_dejson.get("api_endpoint", None)
         account_name = conn.extra_dejson.get("account_name", None)
         conn_config = {
             "username": conn.login,
             "password": conn.password or "",
-            "api_endpoint": DEFAULT_API_URL,
+            "api_endpoint": api_endpoint or DEFAULT_API_URL,
             "database": self.database or database,
             "engine_name": engine_name,
             "engine_url": engine_url,
@@ -185,7 +186,7 @@ class FireboltHook(DbApiHook):
         rm = self.get_resource_manager()
         if engine_name is None:
             if database_name is None:
-                raise FireboltError("Database cannot be not set")
+                raise FireboltError("Database must be set")
             engine = get_default_database_engine(rm, database_name)
         else:
             engine = rm.engines.get_by_name(engine_name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ apache_airflow_provider =
 
 [options.extras_require]
 dev =
-    apache-airflow
+    apache-airflow>=2.2.0
     mypy==0.910
     pre-commit==2.15.0
     pydantic

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
+    apache-airflow>=2.2.0
     firebolt-sdk>=0.9.2
 python_requires = >=3.6
 

--- a/tests/hooks/test_firebolt.py
+++ b/tests/hooks/test_firebolt.py
@@ -75,6 +75,11 @@ class TestFireboltHookConn(unittest.TestCase):
     @patch("firebolt_provider.hooks.firebolt.Settings")
     @patch("firebolt_provider.hooks.firebolt.UsernamePassword")
     def test_get_resource_manager(self, mock_auth, mock_settings, mock_rm):
+        self.connection.extra_dejson = {
+            "engine_name": "test",
+            "account_name": "firebolt",
+        }
+
         self.db_hook.get_resource_manager()
 
         mock_rm.assert_called_once()
@@ -82,6 +87,28 @@ class TestFireboltHookConn(unittest.TestCase):
         mock_settings.assert_called_once_with(
             auth=mock.ANY,
             server="api.app.firebolt.io",
+            default_region="us-east-1",
+        )
+
+    @patch("firebolt_provider.hooks.firebolt.ResourceManager")
+    @patch("firebolt_provider.hooks.firebolt.Settings")
+    @patch("firebolt_provider.hooks.firebolt.UsernamePassword")
+    def test_get_resource_manager_custom_api_endpoint(
+        self, mock_auth, mock_settings, mock_rm
+    ):
+        self.connection.extra_dejson = {
+            "engine_name": "test",
+            "account_name": "firebolt",
+            "api_endpoint": "api.dev.firebolt.io",
+        }
+
+        self.db_hook.get_resource_manager()
+
+        mock_rm.assert_called_once()
+        mock_auth.assert_called_once_with(username="user", password="pw")
+        mock_settings.assert_called_once_with(
+            auth=mock.ANY,
+            server="api.dev.firebolt.io",
             default_region="us-east-1",
         )
 

--- a/tests/hooks/test_firebolt.py
+++ b/tests/hooks/test_firebolt.py
@@ -20,7 +20,7 @@
 import json
 import unittest
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from firebolt.common import Settings
 
@@ -34,7 +34,6 @@ class TestFireboltHookConn(unittest.TestCase):
         self.connection.login = "user"
         self.connection.password = "pw"
         self.connection.schema = "firebolt"
-        self.connection.host = "api_endpoint"
 
         class UnitTestFireboltHook(FireboltHook):
             conn_name_attr = "firebolt_conn_id"
@@ -54,9 +53,10 @@ class TestFireboltHookConn(unittest.TestCase):
         mock_connect.assert_called_once_with(
             username="user",
             password="pw",
-            api_endpoint="api_endpoint",
+            api_endpoint="api.app.firebolt.io",
             database="firebolt",
             engine_name="test",
+            engine_url=None,
             account_name="firebolt",
         )
 
@@ -68,9 +68,10 @@ class TestFireboltHookConn(unittest.TestCase):
         mock_connect.assert_called_once_with(
             username="user",
             password="pw",
-            api_endpoint="api_endpoint",
+            api_endpoint="api.app.firebolt.io",
             database="firebolt",
             engine_name=None,
+            engine_url=None,
             account_name=None,
         )
 
@@ -82,7 +83,7 @@ class TestFireboltHookConn(unittest.TestCase):
             Settings(
                 user="user",
                 password="pw",
-                server="api_endpoint",
+                server="api.app.firebolt.io",
                 default_region="us-east-1",
             )
         )
@@ -125,10 +126,9 @@ class TestFireboltHook(unittest.TestCase):
 
     def test_get_ui_field_behaviour(self):
         widget = {
-            "hidden_fields": ["port"],
-            "relabeling": {"schema": "Database", "host": "API End Point"},
+            "hidden_fields": ["port", "host"],
+            "relabeling": {"schema": "Database"},
             "placeholders": {
-                "host": "firebolt api end point",
                 "schema": "firebolt database",
                 "login": "firebolt userid",
                 "password": "password",
@@ -157,3 +157,49 @@ class TestFireboltHook(unittest.TestCase):
         status, msg = self.db_hook.test_connection()
         assert status is False
         assert msg == "Connection Errors"
+
+    @mock.patch(
+        "firebolt_provider.hooks.firebolt.FireboltHook.get_resource_manager",
+    )
+    def test_engine_action_stop(self, mock_rm_call):
+        mock_rm = MagicMock()
+        mock_engine = MagicMock()
+
+        mock_rm_call.return_value = mock_rm
+        mock_rm.engines.get_by_name.return_value = mock_engine
+
+        self.db_hook.engine_action("engine_name", "stop")
+        mock_rm_call.assert_called_once()
+        mock_rm.engines.get_by_name.assert_called_once_with("engine_name")
+
+        mock_engine.stop.assert_called_once_with(wait_for_stop=True)
+
+    @mock.patch(
+        "firebolt_provider.hooks.firebolt.FireboltHook.get_resource_manager",
+    )
+    @mock.patch(
+        "firebolt_provider.hooks.firebolt.FireboltHook._get_conn_params",
+    )
+    @mock.patch(
+        "firebolt_provider.hooks.firebolt.get_default_database_engine",
+    )
+    def test_engine_action_start_default(
+        self, default_engine_call, conn_params_call, mock_rm_call
+    ):
+        mock_rm = MagicMock()
+        mock_engine = MagicMock()
+
+        conn_params_call.return_value = {
+            "database": "database_name",
+            "engine_name": None,
+            "engine_url": None,
+        }
+        mock_rm_call.return_value = mock_rm
+        default_engine_call.return_value = mock_engine
+
+        self.db_hook.engine_action(None, "start")
+        mock_rm_call.assert_called_once()
+        default_engine_call.assert_called_once_with(mock_rm, "database_name")
+        conn_params_call.assert_called_once()
+
+        mock_engine.start.assert_called_once_with(wait_for_startup=True)

--- a/tests/hooks/test_firebolt.py
+++ b/tests/hooks/test_firebolt.py
@@ -22,8 +22,6 @@ import unittest
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
-from firebolt.common import Settings
-
 from firebolt_provider.hooks.firebolt import FireboltHook
 
 
@@ -51,8 +49,7 @@ class TestFireboltHookConn(unittest.TestCase):
 
         self.db_hook.get_conn()
         mock_connect.assert_called_once_with(
-            username="user",
-            password="pw",
+            auth=mock.ANY,
             api_endpoint="api.app.firebolt.io",
             database="firebolt",
             engine_name="test",
@@ -66,8 +63,7 @@ class TestFireboltHookConn(unittest.TestCase):
 
         self.db_hook.get_conn()
         mock_connect.assert_called_once_with(
-            username="user",
-            password="pw",
+            auth=mock.ANY,
             api_endpoint="api.app.firebolt.io",
             database="firebolt",
             engine_name=None,
@@ -76,16 +72,17 @@ class TestFireboltHookConn(unittest.TestCase):
         )
 
     @patch("firebolt_provider.hooks.firebolt.ResourceManager")
-    def test_get_resource_manager(self, mock_rm):
+    @patch("firebolt_provider.hooks.firebolt.Settings")
+    @patch("firebolt_provider.hooks.firebolt.UsernamePassword")
+    def test_get_resource_manager(self, mock_auth, mock_settings, mock_rm):
         self.db_hook.get_resource_manager()
 
-        mock_rm.assert_called_once_with(
-            Settings(
-                user="user",
-                password="pw",
-                server="api.app.firebolt.io",
-                default_region="us-east-1",
-            )
+        mock_rm.assert_called_once()
+        mock_auth.assert_called_once_with(username="user", password="pw")
+        mock_settings.assert_called_once_with(
+            auth=mock.ANY,
+            server="api.app.firebolt.io",
+            default_region="us-east-1",
         )
 
 

--- a/tests/operators/test_start_stop.py
+++ b/tests/operators/test_start_stop.py
@@ -15,12 +15,7 @@ def test_start_stop_operator(operator: str, mocker: MockerFixture):
     get_db_hook_mock = mocker.patch("firebolt_provider.operators.firebolt.get_db_hook")
 
     db_hook_mock = MagicMock()
-    rm_mock = MagicMock()
-    engine_mock = MagicMock()
-
-    db_hook_mock.get_resource_manager.return_value = rm_mock
     get_db_hook_mock.return_value = db_hook_mock
-    rm_mock.engines.get_by_name.return_value = engine_mock
 
     operator_params = {"task_id": "task_id", "engine_name": "engine_name"}
 
@@ -30,11 +25,8 @@ def test_start_stop_operator(operator: str, mocker: MockerFixture):
         engine_operator = FireboltStopEngineOperator(**operator_params)
 
     engine_operator.execute({})
-    get_db_hook_mock.assert_called_once()
-
-    rm_mock.engines.get_by_name.assert_called_once_with("engine_name")
 
     if operator == "start":
-        engine_mock.start.assert_called_once_with(wait_for_startup=True)
+        db_hook_mock.engine_action.assert_called_once_with("engine_name", "start")
     else:
-        engine_mock.stop.assert_called_once_with(wait_for_stop=True)
+        db_hook_mock.engine_action.assert_called_once_with("engine_name", "stop")


### PR DESCRIPTION
A lot of small changes:
- Change username/password with auth object
- Add unit-tests coverage badge
- Rework Start/Stop Engine Operators, such that, they can access engine_name from airflow connection and default database name
- Make it possible to pass engine URL for the connection
- Remove Host parameter (it is not needed for the clients, but introduces some confusion)
- Add support of Airflow>=2.2.0