### PR TITLE
Added new line between module parameters and description

### DIFF
--- a/firebolt_provider/hooks/firebolt.py
+++ b/firebolt_provider/hooks/firebolt.py
@@ -55,6 +55,7 @@ class FireboltHook(DbApiHook):
     This hook requires the firebolt_conn_id connection. The firebolt login,
     password, and api_endpoint field must be setup in the connection.
     Other inputs can be defined in the connection or hook instantiation.
+    
     :param firebolt_conn_id: Reference to
         :ref:`Firebolt connection id<howto/connection:firebolt>`
     :type firebolt_conn_id: str


### PR DESCRIPTION
As part of a design overhaul we're doing to the Astronomer Registry, we want to make sure that all hooks, modules, and more that we're displaying are following standard styling. This PR is to add a newline between the docstring in the hook and the parameters. 