### PR TITLE
feat: Airflow 1.10 support

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check title name convention
-        uses: jef/conventional-commits-pr-action@v1.0.0
+        uses: jef/conventional-commits-pr-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 .coverage
 .idea/
+venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
           - --remove-unused-variables
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.12.0
     hooks:
       - id: isort
 
@@ -34,17 +34,18 @@ repos:
         language-version: 3.9
 
   - repo: https://github.com/dfm/black_nbconvert
-    rev: v0.3.0
+    rev: v0.4.0
     hooks:
       - id: black_nbconvert
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.7.9
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-tidy-imports
           - flake8-quotes
+
   - repo: local
     hooks:
       - id: mypy

--- a/firebolt_provider/hooks/firebolt.py
+++ b/firebolt_provider/hooks/firebolt.py
@@ -20,7 +20,7 @@
 import json
 from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
-from airflow.hooks.dbapi import DbApiHook
+from airflow.version import version as airflow_version
 from firebolt.client import DEFAULT_API_URL
 from firebolt.client.auth import UsernamePassword
 from firebolt.common import Settings
@@ -28,6 +28,17 @@ from firebolt.db import Connection, connect
 from firebolt.model.engine import Engine
 from firebolt.service.manager import ResourceManager
 from firebolt.utils.exception import FireboltError
+
+if airflow_version.startswith("1.10"):
+    from airflow.hooks.dbapi_hook import DbApiHook  # type: ignore
+    from airflow.models.connection import Connection as AirflowConnection
+
+    # Show Firebolt in list of connections in UI
+    if ("firebolt", "Firebolt") not in AirflowConnection._types:
+        AirflowConnection._types.append(("firebolt", "Firebolt"))
+else:
+    # Airflow 2.0 path for the base class
+    from airflow.hooks.dbapi import DbApiHook
 
 
 def get_default_database_engine(rm: ResourceManager, database_name: str) -> Engine:

--- a/firebolt_provider/operators/firebolt.py
+++ b/firebolt_provider/operators/firebolt.py
@@ -18,7 +18,7 @@
 from typing import Any, List, Optional, Sequence, Union
 
 from airflow.models import BaseOperator, BaseOperatorLink
-from airflow.models.taskinstance import TaskInstanceKey
+from airflow.utils.decorators import apply_defaults
 
 from firebolt_provider.hooks.firebolt import FireboltHook
 
@@ -46,7 +46,7 @@ class RegistryLink(BaseOperatorLink):
 
     name = "Astronomer Registry"
 
-    def get_link(self, operator, ti_key: TaskInstanceKey) -> str:  # type: ignore
+    def get_link(self, operator, ti_key) -> str:  # type: ignore
         """Get link to registry page."""
 
         registry_link = (
@@ -83,6 +83,7 @@ class FireboltOperator(BaseOperator):
     template_ext = (".sql",)
     ui_color = "#b4e0ff"
 
+    @apply_defaults
     def __init__(
         self,
         sql: Union[str, List[str]],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,3 @@
-[build-system]
-requires = [
-    "setuptools>=42",
-    "wheel"
-]
-build-backend = "setuptools.build_meta"
-
 # configure isort to be compatible with black
 # source: https://black.readthedocs.io/en/stable/compatible_configs.html#configuration
 [tool.isort]

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    apache-airflow>=2.2.0
+    apache-airflow>=1.10.0
     firebolt-sdk>=0.9.2
 python_requires = >=3.6
 
@@ -34,7 +34,6 @@ apache_airflow_provider =
 
 [options.extras_require]
 dev =
-    apache-airflow>=2.2.0
     mypy==0.910
     pre-commit==2.15.0
     pydantic


### PR DESCRIPTION
Adding backwards-compatibility with Airflow 1.10.*

In order for UI to show Firebolt as a connection type adding a mapping to the static list of connections. Connection fields are the same for all the connections in Airflow v1.

Bumping Python version on the PR check due to isort breaking as one of its dependencies was not pinned. New version of isort fixes the issue but also discontinued python 3.7