### PR TITLE
build: Update python requirements to 3.7 and up

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
 project_urls =
     Bug Tracker = https://github.com/firebolt-db/airflow-provider-firebolt/issues
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,10 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 project_urls =
     Bug Tracker = https://github.com/firebolt-db/airflow-provider-firebolt/issues
 
@@ -26,7 +26,7 @@ packages = find:
 install_requires =
     apache-airflow>=1.10.0
     firebolt-sdk>=0.9.2
-python_requires = >=3.6
+python_requires = >=3.7
 
 [options.entry_points]
 apache_airflow_provider =


### PR DESCRIPTION
Dependency here, firebolt-sdk, only supports Python 3.7 and up. In order to improve clarity we should also specify it in our airflow setup. Also, before this change if a user is trying to install the package on 3.6 it fails on firebolt-sdk with "firebolt-sdk not found". I believe with this change it will be immediately clear why the package is not installing.