### PR TITLE
fix: Account name in start/stop operator

### DIFF
--- a/firebolt_provider/hooks/firebolt.py
+++ b/firebolt_provider/hooks/firebolt.py
@@ -166,6 +166,7 @@ class FireboltHook(DbApiHook):
             Settings(
                 auth=UsernamePassword(username=username, password=password),
                 server=conn_config["api_endpoint"],
+                account_name=conn_config["account_name"],
                 default_region="us-east-1",
             )
         )

--- a/tests/hooks/test_firebolt.py
+++ b/tests/hooks/test_firebolt.py
@@ -77,7 +77,6 @@ class TestFireboltHookConn(unittest.TestCase):
     def test_get_resource_manager(self, mock_auth, mock_settings, mock_rm):
         self.connection.extra_dejson = {
             "engine_name": "test",
-            "account_name": "firebolt",
         }
 
         self.db_hook.get_resource_manager()
@@ -86,6 +85,7 @@ class TestFireboltHookConn(unittest.TestCase):
         mock_auth.assert_called_once_with(username="user", password="pw")
         mock_settings.assert_called_once_with(
             auth=mock.ANY,
+            account_name=None,
             server="api.app.firebolt.io",
             default_region="us-east-1",
         )
@@ -109,6 +109,7 @@ class TestFireboltHookConn(unittest.TestCase):
         mock_settings.assert_called_once_with(
             auth=mock.ANY,
             server="api.dev.firebolt.io",
+            account_name="firebolt",
             default_region="us-east-1",
         )
 


### PR DESCRIPTION
We weren't accounting for account name for resource manager. This fixes that and adds unit tests.

Confirmed working in a local airflow setup.