### PR TITLE
lock sdk version to 0.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ project_urls =
 packages = find:
 install_requires =
     apache-airflow>=1.10.0
-    firebolt-sdk>=0.9.2
+    firebolt-sdk>=0.9.2,<1.0.0
 python_requires = >=3.7
 
 [options.entry_points]


### PR DESCRIPTION
Lock python sdk version to only use 0.x versions