### PR TITLE
feat: Allow both FB versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,20 +46,25 @@ You can install this package via
 pip install airflow-provider-firebolt
 ```
 
-`airflow-provider-firebolt` requires `apache-airflow` 2.2.0+ and `firebolt-sdk` 0.9.2+.
+`airflow-provider-firebolt` requires `apache-airflow` 2.0+ and `firebolt-sdk` 1.1+.
 
 
 <a id="configuration"></a>
 ## Configuration
 
-In the Airflow user interface, configure a Connection for Firebolt. Most of the Connection config fields will be left blank. Configure the following fields:
+In the Airflow user interface, configure a Connection for Firebolt. Configure the following fields:
 
 * `Conn Id`: `firebolt_conn_id`
 * `Conn Type`: `Firebolt`
-* `Login`: Firebolt Login
-* `Password`: Firebolt Password
+* `Client ID`: Service account ID
+* `Client Secret`: Service account secret
 * `Engine_Name`: Firebolt Engine Name
+* `Account`: Name of the account you're connecting to
 
+Client id and secret credentials can be obtained by registering a [Service account](https://docs.firebolt.io/godocs/Guides/managing-your-organization/service-accounts.html#manage-service-accounts).
+
+### Note
+If you're accessing Firebolt UI via `app.firebolt.io` then use Username and Password instead of Client ID and Client Secret to connect.
 
 <a id="modules"></a>
 ## Modules
@@ -70,7 +75,7 @@ In the Airflow user interface, configure a Connection for Firebolt. Most of the 
 
 [operators.firebolt.FireboltOperator](https://github.com/firebolt-db/airflow-provider-firebolt/blob/main/firebolt_provider/operators/firebolt.py) runs a provided SQL script against Firebolt and returns results.
 
-[operators.firebolt.FireboltStartEngineOperator](https://github.com/firebolt-db/airflow-provider-firebolt/blob/main/firebolt_provider/operators/firebolt.py) 
+[operators.firebolt.FireboltStartEngineOperator](https://github.com/firebolt-db/airflow-provider-firebolt/blob/main/firebolt_provider/operators/firebolt.py)
 [operators.firebolt.FireboltStopEngineOperator](https://github.com/firebolt-db/airflow-provider-firebolt/blob/main/firebolt_provider/operators/firebolt.py) starts/stops the specified engine, and waits until it is actually started/stopped. If the `engine_name` is not specified, it will use the `engine_name` from the connection, if it also not specified it will start the default engine of the connection database. Note: start/stop operator requires actual engine name, if engine URL is specified instead, start/stop engine operators will not be able to handle it correctly.
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ project_urls =
 packages = find:
 install_requires =
     apache-airflow>=1.10.0
-    firebolt-sdk>=1.0.0a
+    firebolt-sdk>=1.1.0
 python_requires = >=3.7
 
 [options.entry_points]

--- a/tests/hooks/test_firebolt.py
+++ b/tests/hooks/test_firebolt.py
@@ -22,6 +22,7 @@ import unittest
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
+from firebolt.client.auth import ClientCredentials, UsernamePassword
 from firebolt.utils.exception import FireboltError
 
 from firebolt_provider.hooks.firebolt import FireboltHook
@@ -54,15 +55,13 @@ class TestFireboltHookConn(unittest.TestCase):
             engine_name="test",
             account_name="firebolt",
         )
+        # Verify that the auth object is a ClientCredentials object
+        self.assertIsInstance(mock_connect.call_args[1]["auth"], ClientCredentials)
 
     @patch("firebolt_provider.hooks.firebolt.connect")
-    def test_get_conn_no_account(self, mock_connect):
-        self.connection.extra_dejson["account_name"] = None
-
-        with self.assertRaises(FireboltError):
-            self.db_hook.get_conn()
-
-        self.connection.extra_dejson["account_name"] = "firebolt"
+    def test_get_username_pass_conn(self, mock_connect):
+        self.connection.login = "usern@me.com"
+        self.connection.password = "password"
 
         self.db_hook.get_conn()
 
@@ -73,6 +72,8 @@ class TestFireboltHookConn(unittest.TestCase):
             engine_name="test",
             account_name="firebolt",
         )
+        # Verify that the auth object is a UsernamePassword object
+        self.assertIsInstance(mock_connect.call_args[1]["auth"], UsernamePassword)
 
     @patch("firebolt_provider.hooks.firebolt.connect")
     def test_get_conn_custom_api_endpoint(self, mock_connect):
@@ -91,11 +92,6 @@ class TestFireboltHookConn(unittest.TestCase):
     @patch("firebolt_provider.hooks.firebolt.ResourceManager")
     @patch("firebolt_provider.hooks.firebolt.ClientCredentials")
     def test_get_resource_manager(self, mock_auth, mock_rm):
-        self.connection.extra_dejson["account_name"] = None
-
-        with self.assertRaises(FireboltError):
-            self.db_hook.get_resource_manager()
-
         self.connection.extra_dejson["account_name"] = "firebolt"
 
         self.db_hook.get_resource_manager()


### PR DESCRIPTION
Allowing both new and old Firebolt users to use the same connector.

Tested auth and running a sample task on a local Airflow deployment.