### PR TITLE
fix: Start stop engine operator errors

### DIFF
--- a/firebolt_provider/hooks/firebolt.py
+++ b/firebolt_provider/hooks/firebolt.py
@@ -187,7 +187,7 @@ class FireboltHook(DbApiHook):
                 raise FireboltError("Engine name must be provided")
 
         rm = self.get_resource_manager()
-        return rm.engines.get(engine_name)
+        return rm.engines.get_by_name(engine_name)
 
     def engine_action(self, engine_name: Optional[str], action: str) -> None:
         """

--- a/firebolt_provider/hooks/firebolt.py
+++ b/firebolt_provider/hooks/firebolt.py
@@ -158,9 +158,10 @@ class FireboltHook(DbApiHook):
     def get_resource_manager(self) -> ResourceManager:
         """Return Resource Manager"""
         conn_config = self._get_conn_params()
+        auth = _determine_auth(conn_config.client_id, conn_config.client_secret)
 
         manager = ResourceManager(
-            auth=ClientCredentials(conn_config.client_id, conn_config.client_secret),
+            auth=auth,
             api_endpoint=conn_config.api_endpoint,
             account_name=conn_config.account_name,
         )

--- a/tests/hooks/test_firebolt.py
+++ b/tests/hooks/test_firebolt.py
@@ -106,7 +106,9 @@ class TestFireboltHookConn(unittest.TestCase):
     @patch("firebolt_provider.hooks.firebolt.ResourceManager")
     @patch("firebolt_provider.hooks.firebolt.UsernamePassword")
     @patch("firebolt_provider.hooks.firebolt.ClientCredentials")
-    def test_get_resource_manager_username_password(self, mock_other_auth, mock_auth, mock_rm):
+    def test_get_resource_manager_username_password(
+        self, mock_other_auth, mock_auth, mock_rm
+    ):
         self.connection.login = "my@username.com"
         self.connection.extra_dejson["account_name"] = "firebolt"
 

--- a/tests/hooks/test_firebolt.py
+++ b/tests/hooks/test_firebolt.py
@@ -101,7 +101,24 @@ class TestFireboltHookConn(unittest.TestCase):
             account_name="firebolt",
             api_endpoint="api.app.firebolt.io",
         )
-        mock_auth.assert_called_once_with("client_id", "client_secret")
+        mock_auth.assert_called_once_with("client_id", "client_secret", True)
+
+    @patch("firebolt_provider.hooks.firebolt.ResourceManager")
+    @patch("firebolt_provider.hooks.firebolt.UsernamePassword")
+    @patch("firebolt_provider.hooks.firebolt.ClientCredentials")
+    def test_get_resource_manager_username_password(self, mock_other_auth, mock_auth, mock_rm):
+        self.connection.login = "my@username.com"
+        self.connection.extra_dejson["account_name"] = "firebolt"
+
+        self.db_hook.get_resource_manager()
+
+        mock_rm.assert_called_once_with(
+            auth=mock.ANY,
+            account_name="firebolt",
+            api_endpoint="api.app.firebolt.io",
+        )
+        mock_auth.assert_called_once_with("my@username.com", "client_secret", True)
+        mock_other_auth.assert_not_called()
 
     @patch("firebolt_provider.hooks.firebolt.ResourceManager")
     @patch("firebolt_provider.hooks.firebolt.ClientCredentials")
@@ -115,7 +132,7 @@ class TestFireboltHookConn(unittest.TestCase):
             api_endpoint="api.dev.firebolt.io",
             account_name="firebolt",
         )
-        mock_auth.assert_called_once_with("client_id", "client_secret")
+        mock_auth.assert_called_once_with("client_id", "client_secret", True)
 
 
 class TestFireboltHook(unittest.TestCase):
@@ -195,11 +212,11 @@ class TestFireboltHook(unittest.TestCase):
         mock_engine = MagicMock()
 
         mock_rm_call.return_value = mock_rm
-        mock_rm.engines.get.return_value = mock_engine
+        mock_rm.engines.get_by_name.return_value = mock_engine
 
         self.db_hook.engine_action("engine_name", "stop")
         mock_rm_call.assert_called_once()
-        mock_rm.engines.get.assert_called_once_with("engine_name")
+        mock_rm.engines.get_by_name.assert_called_once_with("engine_name")
 
         mock_engine.stop.assert_called_once()
 


### PR DESCRIPTION
FIR-29930

Auth needs to support both old and new authentication.
Also, engine.get has changed in parameters, using safer get_by_name which is the same for both SDK implementations.