### PR TITLE
feat: Return query result from hook

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -38,7 +38,6 @@ jobs:
 
       - name: Run unit tests
         run: |
-          pip freeze
           pytest --cov=firebolt_provider/ tests/ --cov-report=xml
 
       - name: Upload coverage report

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -41,7 +41,7 @@ jobs:
           pytest --cov=firebolt_provider/ tests/ --cov-report=xml
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-coverage-report
           path: coverage.xml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
@@ -38,6 +38,7 @@ jobs:
 
       - name: Run unit tests
         run: |
+          pip freeze
           pytest --cov=firebolt_provider/ tests/ --cov-report=xml
 
       - name: Upload coverage report

--- a/firebolt_provider/hooks/firebolt.py
+++ b/firebolt_provider/hooks/firebolt.py
@@ -61,6 +61,7 @@ class FireboltHook(DbApiHook):
     default_conn_name = "firebolt_default"
     conn_type = "firebolt"
     hook_name = "Firebolt"
+    supports_autocommit = False
 
     ConnectionParameters = namedtuple(
         "ConnectionParameters",
@@ -200,38 +201,6 @@ class FireboltHook(DbApiHook):
 
         """
         self._run_action(self._get_engine(engine_name), action)
-
-    def run(
-        self,
-        sql: Union[str, List],
-        autocommit: bool = False,
-        parameters: Optional[Sequence] = None,
-        handler: Optional[Callable] = None,
-    ) -> None:
-        """
-        Runs a command or a list of commands. Pass a list of sql
-        statements to the sql parameter to get them to execute
-        sequentially
-        :param sql: the sql statement to be executed (str) or a list of
-            sql statements to execute
-        :type sql: str or list
-        :param autocommit: What to set the connection's autocommit setting to
-            before executing the query.
-        :type autocommit: bool
-        :param parameters: The parameters to render the SQL query with.
-        :type parameters: dict or iterable
-        """
-        scalar = isinstance(sql, str)
-        if scalar:
-            sql = [sql]
-        with self.get_conn() as conn:
-            with conn.cursor() as cursor:
-                for sql_statement in sql:
-                    if parameters:
-                        cursor.execute(sql_statement, parameters)
-                    else:
-                        cursor.execute(sql_statement)
-                    self.log.info(f"Rows returned: {cursor.rowcount}")
 
     def test_connection(self) -> Tuple[bool, str]:
         """Test the Firebolt connection by running a simple query."""

--- a/firebolt_provider/hooks/firebolt.py
+++ b/firebolt_provider/hooks/firebolt.py
@@ -18,7 +18,7 @@
 #
 
 from collections import namedtuple
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 from airflow.version import version as airflow_version
 from firebolt.client import DEFAULT_API_URL

--- a/tests/hooks/test_firebolt.py
+++ b/tests/hooks/test_firebolt.py
@@ -237,3 +237,16 @@ class TestFireboltHook(unittest.TestCase):
 
         with self.assertRaises(FireboltError):
             self.db_hook.engine_action(None, "start")
+
+    def test_run_returns_results(self):
+        sql = ["SQL1", "SQL2"]
+        self.cursor.fetchall.return_value = [(1, 2)]
+        res = self.db_hook.run(sql, handler=lambda cur: cur.fetchall())
+        assert res == [[(1, 2)], [(1, 2)]]
+
+        sql = "SQL1; SQL2"
+        res = self.db_hook.run(sql, handler=lambda cur: cur.fetchall(), return_last=False, split_statements=True)
+        assert res == [[(1, 2)], [(1, 2)]]
+
+        res = self.db_hook.run(sql, handler=lambda cur: cur.fetchall(), return_last=True, split_statements=True)
+        assert res == [(1, 2)]

--- a/tests/hooks/test_firebolt.py
+++ b/tests/hooks/test_firebolt.py
@@ -157,20 +157,20 @@ class TestFireboltHook(unittest.TestCase):
         sql = "SQL"
         parameters = ("param1", "param2")
         self.db_hook.run(sql=sql, parameters=parameters)
-        self.conn.__enter__().cursor().__enter__().execute.assert_called_once_with(
+        self.conn.cursor().execute.assert_called_once_with(
             sql, parameters
         )
 
     def test_run_with_single_query(self):
         sql = "SQL"
         self.db_hook.run(sql)
-        self.conn.__enter__().cursor().__enter__().execute.assert_called_once_with(sql)
+        self.conn.cursor().execute.assert_called_once_with(sql)
 
     def test_run_multi_queries(self):
         sql = ["SQL1", "SQL2"]
         self.db_hook.run(sql, autocommit=True)
         for query in sql:
-            self.conn.__enter__().cursor().__enter__().execute.assert_any_call(query)
+            self.conn.cursor().execute.assert_any_call(query)
 
     def test_get_ui_field_behaviour(self):
         widget = {

--- a/tests/hooks/test_firebolt.py
+++ b/tests/hooks/test_firebolt.py
@@ -22,7 +22,7 @@ import unittest
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
-from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
+from airflow.providers.common.sql.hooks.sql import fetch_all_handler
 from firebolt.client.auth import ClientCredentials, UsernamePassword
 from firebolt.utils.exception import FireboltError
 

--- a/tests/hooks/test_firebolt.py
+++ b/tests/hooks/test_firebolt.py
@@ -157,9 +157,7 @@ class TestFireboltHook(unittest.TestCase):
         sql = "SQL"
         parameters = ("param1", "param2")
         self.db_hook.run(sql=sql, parameters=parameters)
-        self.conn.cursor().execute.assert_called_once_with(
-            sql, parameters
-        )
+        self.conn.cursor().execute.assert_called_once_with(sql, parameters)
 
     def test_run_with_single_query(self):
         sql = "SQL"
@@ -245,8 +243,18 @@ class TestFireboltHook(unittest.TestCase):
         assert res == [[(1, 2)], [(1, 2)]]
 
         sql = "SQL1; SQL2"
-        res = self.db_hook.run(sql, handler=lambda cur: cur.fetchall(), return_last=False, split_statements=True)
+        res = self.db_hook.run(
+            sql,
+            handler=lambda cur: cur.fetchall(),
+            return_last=False,
+            split_statements=True,
+        )
         assert res == [[(1, 2)], [(1, 2)]]
 
-        res = self.db_hook.run(sql, handler=lambda cur: cur.fetchall(), return_last=True, split_statements=True)
+        res = self.db_hook.run(
+            sql,
+            handler=lambda cur: cur.fetchall(),
+            return_last=True,
+            split_statements=True,
+        )
         assert res == [(1, 2)]

--- a/tests/hooks/test_firebolt.py
+++ b/tests/hooks/test_firebolt.py
@@ -22,6 +22,7 @@ import unittest
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
 from firebolt.client.auth import ClientCredentials, UsernamePassword
 from firebolt.utils.exception import FireboltError
 
@@ -239,13 +240,13 @@ class TestFireboltHook(unittest.TestCase):
     def test_run_returns_results(self):
         sql = ["SQL1", "SQL2"]
         self.cursor.fetchall.return_value = [(1, 2)]
-        res = self.db_hook.run(sql, handler=lambda cur: cur.fetchall())
+        res = self.db_hook.run(sql, handler=fetch_all_handler)
         assert res == [[(1, 2)], [(1, 2)]]
 
         sql = "SQL1; SQL2"
         res = self.db_hook.run(
             sql,
-            handler=lambda cur: cur.fetchall(),
+            handler=fetch_all_handler,
             return_last=False,
             split_statements=True,
         )
@@ -253,7 +254,7 @@ class TestFireboltHook(unittest.TestCase):
 
         res = self.db_hook.run(
             sql,
-            handler=lambda cur: cur.fetchall(),
+            handler=fetch_all_handler,
             return_last=True,
             split_statements=True,
         )


### PR DESCRIPTION
Removed our custom `run` implementation in favor of the default airflow implementation, which works just fine and has results returned out of the box