### PR TITLE
ci: update ci release action to use python 3.8

### DIFF
--- a/.github/workflows/python-release-org.yml
+++ b/.github/workflows/python-release-org.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Updated release action to use python 3.8