### PR TITLE
fix(FIR-42325): Default httpx logging level to Warn

### DIFF
--- a/firebolt_provider/__init__.py
+++ b/firebolt_provider/__init__.py
@@ -10,7 +10,8 @@ def get_provider_info() -> Dict[str, Any]:
         "description": "A Firebolt provider for Apache Airflow.",
         "hook-class-names": ["firebolt_provider.hooks.firebolt.FireboltHook"],
         "connection-types": [
-            {   "connection-type": "firebolt",
+            {
+                "connection-type": "firebolt",
                 "hook-class-name": "firebolt_provider.hooks.firebolt.FireboltHook",
             }
         ],

--- a/firebolt_provider/__init__.py
+++ b/firebolt_provider/__init__.py
@@ -9,5 +9,10 @@ def get_provider_info() -> Dict[str, Any]:
         "name": "Firebolt Provider",
         "description": "A Firebolt provider for Apache Airflow.",
         "hook-class-names": ["firebolt_provider.hooks.firebolt.FireboltHook"],
+        "connection-types": [
+            {   "connection-type": "firebolt",
+                "hook-class-name": "firebolt_provider.hooks.firebolt.FireboltHook",
+            }
+        ],
         "extra-links": ["firebolt_provider.operators.firebolt.RegistryLink"],
     }

--- a/firebolt_provider/hooks/firebolt.py
+++ b/firebolt_provider/hooks/firebolt.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+import logging
 from collections import namedtuple
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -39,6 +40,10 @@ if airflow_version.startswith("1.10"):
 else:
     # Airflow 2.0 path for the base class
     from airflow.hooks.dbapi import DbApiHook
+
+# Reduce noise from httpx logger
+httpx_logger = logging.getLogger("httpx")
+httpx_logger.setLevel(logging.WARNING)
 
 
 class FireboltHook(DbApiHook):


### PR DESCRIPTION
Raw HTTP calls are rarely useful for the user. However, by default Airflow sets log level to INFO for all dependencies. This causes httpx to print every call.
Adjusting it on import. 
Changes in __init__.py are for compatibility with the new airbyte version.